### PR TITLE
add filter to stream

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ function createFile(filepath: string) {
     cwd: process.cwd(),
     base: process.cwd(),
     path: filepath,
-    contents: null
+    contents: null,
   });
 }
 
@@ -54,10 +54,10 @@ export class Store extends EventEmitter {
     return Object.values(this.store);
   }
 
-  stream(): PassThrough {
+  stream(filter: (file: File) => boolean = () => true): PassThrough {
     const stream = new PassThrough({ objectMode: true, autoDestroy: true });
     setImmediate(() => {
-      this.each((file: File) => stream.write(file));
+      this.each((file: File) => filter(file) && stream.write(file));
       stream.end();
     });
 
@@ -67,4 +67,4 @@ export class Store extends EventEmitter {
 
 export function create(): Store {
   return new Store();
-};
+}

--- a/test/index.js
+++ b/test/index.js
@@ -148,5 +148,21 @@ describe('mem-fs', () => {
         done();
       });
     });
+
+    it('returns an object stream for each filtered file', function (done) {
+      let index = 0;
+      const files = [fixtureA, fixtureB];
+      const stream = this.store.stream((file) => file.path.endsWith('file-a.txt'));
+
+      stream.on('data', (file) => {
+        assert.equal(path.resolve(files[index]), file.path);
+        index++;
+      });
+
+      stream.on('end', () => {
+        assert.equal(index, 1);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
Filtering inside a pipeline stream is quite slow.
A initial filter allows to improve the speed significantly in some scenarios.