### PR TITLE
add refresh operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple in-memory vinyl file store.
 You access a file using `store#get()` method. If the file is in memory, it will be used. Otherwise, we'll load the file from the file-system.
 
 ```js
-import { create } from 'mem-fs'
+import { create } from 'mem-fs';
 
 const store = create();
 store.get('/test/file.txt');
@@ -49,6 +49,10 @@ Using `store#all()`, you can get every file stored in the file system.
 ### Check existence in the file system
 
 Using `store#existsInMemory()`, you can check if the file already exists in the file system without loading it from disk.
+
+### Refresh files
+
+Using `store#refresh()`, you can update one or all file path references after a `stream()`.
 
 ### Stream every file stored in the file system
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,18 @@ export class Store<StoreFile extends { path: string } = File> extends EventEmitt
     return this;
   }
 
+  refresh(filepath?: string): this {
+    for (const each of filepath ? [path.resolve(filepath)] : this.store.keys()) {
+      const file = this.store.get(each);
+      if (file && file.path !== each) {
+        this.store.delete(each);
+        this.store.set(file.path, file);
+      }
+    }
+
+    return this;
+  }
+
   each(onEach: (file: StoreFile) => void): this {
     this.store.forEach((file) => {
       onEach(file);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -132,6 +132,49 @@ describe('mem-fs', () => {
     });
   });
 
+  describe('#refresh()', () => {
+    it('is chainable', () => {
+      assert.equal(store.add(coffeeFile), store);
+    });
+
+    beforeEach(() => {
+      store.get(fixtureA);
+      store.get(fixtureB);
+    });
+
+    it('passing the filename, refreshes a single file', () => {
+      const renamed = '.renamed';
+      const fixtureAFile = store.get(fixtureA);
+      fixtureAFile.path += renamed;
+
+      const fixtureBFile = store.get(fixtureB);
+      fixtureBFile.path += renamed;
+
+      store.refresh(fixtureA);
+
+      expect(store.get(fixtureA)).not.toBe(fixtureAFile);
+      expect(store.get(fixtureA + renamed)).toBe(fixtureAFile);
+      expect(store.get(fixtureB + renamed)).not.toBe(fixtureBFile);
+      expect(store.get(fixtureB)).toBe(fixtureBFile);
+    });
+
+    it('refreshes multiple files', () => {
+      const renamed = '.renamed';
+      const fixtureAFile = store.get(fixtureA);
+      fixtureAFile.path += renamed;
+
+      const fixtureBFile = store.get(fixtureB);
+      fixtureBFile.path += renamed;
+
+      store.refresh();
+
+      expect(store.get(fixtureA)).not.toBe(fixtureAFile);
+      expect(store.get(fixtureA + renamed)).toBe(fixtureAFile);
+      expect(store.get(fixtureB)).not.toBe(fixtureBFile);
+      expect(store.get(fixtureB + renamed)).toBe(fixtureBFile);
+    });
+  });
+
   describe('#stream()', () => {
     beforeEach(() => {
       store.get(fixtureA);


### PR DESCRIPTION
The idea is to allow to rename a file inside a stream.
```
await pipeline(store.stream(), renamePassthrough(), ...);
store.refresh();
```

### Alternative implementations:
#### Delete operation:
requires some callbacks like `renamePassthrough({ rename: (from, to) => store.add(to, store.get(from)).delete(from) })`

#### fromStream:
Recreates the store from stream `await pipeline(store.stream(), renamePassthrough(), store.fromStream())`
This approach is interesting but it's not compatible with stream filters  `await pipeline(store.stream({ filter: () => false }), renamePassthrough(), store.fromStream())`