### PR TITLE
fix: ensure directories return contents=null in loadFile across all OSes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { vinylFileSync } from 'vinyl-file';
 import File from 'vinyl';
 import { type PipelineTransform, Readable, Transform } from 'stream';
 import { pipeline } from 'stream/promises';
+import fs from 'node:fs';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FileTransform<File> = PipelineTransform<PipelineTransform<any, File>, File>;
@@ -30,9 +31,20 @@ export function isFileTransform<StoreFile extends { path: string } = File>(
 }
 
 export function loadFile(filepath: string): File {
+  const stat = fs.statSync(filepath, { throwIfNoEntry: false });
+  if (stat?.isDirectory?.()) {
+    return new File({
+      cwd: process.cwd(),
+      base: process.cwd(),
+      path: filepath,
+      stat,
+      contents: null,
+    }) as unknown as File;
+  }
+
   try {
     return vinylFileSync(filepath) as unknown as File;
-  } catch (err) {
+  } catch {
     return new File({
       cwd: process.cwd(),
       base: process.cwd(),

--- a/test/load-file.spec.ts
+++ b/test/load-file.spec.ts
@@ -1,0 +1,15 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { loadFile } from '../src/index.ts';
+import { describe, it, expect } from 'vitest';
+
+describe('loadFile', () => {
+  it('should return contents=null for directories', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'mfe-'));
+    const file = loadFile(dir);
+    expect(file).toBeTruthy();
+    expect(file.stat?.isDirectory?.()).toBe(true);
+    expect(file.contents).toBeNull();
+  });
+});


### PR DESCRIPTION
On NetBSD 10 evbarm/aarch64 (Node v22.16.0), fs.readFileSync(dir) returns 4096 bytes instead of throwing EISDIR.
This causes vinylFileSync(dir) to succeed, so loadFile(dir) produces a File with non-null contents, and mem-fs-editor#exists(dir) incorrectly returns true.

The README specifies that directories should return an empty Vinyl (contents: null).

Fix: Add an explicit stat.isDirectory() guard in loadFile.
Test: Added test/load-file.spec.ts to confirm that loadFile(dir) → contents:null on all platforms.

This makes behavior consistent across Linux, macOS, Windows, and NetBSD.